### PR TITLE
Fix code scanning alert no. 16: Clear-text logging of sensitive information

### DIFF
--- a/code/frameworks/angular/src/client/docs/__testfixtures__/doc-button/input.ts
+++ b/code/frameworks/angular/src/client/docs/__testfixtures__/doc-button/input.ts
@@ -185,7 +185,7 @@ export class InputComponent<T> {
    * @param password Some `password`.
    */
   private privateMethod(password: string) {
-    console.log(password);
+    console.log('Password received');
   }
 
   @Input('showKeyAlias')


### PR DESCRIPTION
Fixes [https://github.com/akabarki/storybook/security/code-scanning/16](https://github.com/akabarki/storybook/security/code-scanning/16)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. Instead of logging the actual password, we can log a placeholder or a masked version of the password to indicate that a password was processed without exposing its value.

- Replace the `console.log(password)` statement with a log message that does not include the actual password.
- Update the `privateMethod` in the `InputComponent` class to log a placeholder message instead of the password.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
